### PR TITLE
Merge fork customized for chef_portal

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'mattstratton@chef.io'
 license 'Apache 2.0'
 description 'Installs/Configures guacamole'
 long_description 'Installs/Configures guacamole-server, an HTML5 remote desktop client thing'
-version '0.1.0'
+version '0.1.1'
 
 depends 'tomcat', '~> 0.17.3'
 depends 'java', '~> 1.31.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,6 +25,7 @@ end
 remote_file "#{Chef::Config[:file_cache_path]}/guacamole-server-#{node['guacamole']['version']}.tar.gz" do
   source "http://tcpdiag.dl.sourceforge.net/project/guacamole/current/source/guacamole-server-#{node['guacamole']['version']}.tar.gz"
   mode '0644'
+  action :create_if_missing
 end
 
 bash "build-and-install-guacamole" do
@@ -35,6 +36,7 @@ bash "build-and-install-guacamole" do
     make && make install
     ldconfig
   EOF
+  creates "#{Chef::Config[:file_cache_path]}/guacamole-server-#{node['guacamole']['version']}/config.log"
 end
 
 service 'guacd' do
@@ -77,6 +79,7 @@ directory "#{node['tomcat']['home']}/.guacamole"
 remote_file "/var/lib/guacamole/guacamole.war" do
   source "http://iweb.dl.sourceforge.net/project/guacamole/current/binary/guacamole-#{node['guacamole']['version']}.war"
   mode '0644'
+  action :create_if_missing
 end
 
 template '/etc/guacamole/guacamole.properties' do
@@ -106,6 +109,7 @@ service 'tomcat_service' do
   service_name node['tomcat']['base_instance']
   supports :restart => true
   action :nothing
+  retries 5
 end
 
 # nginx stuff

--- a/templates/default/user-mapping.xml.erb
+++ b/templates/default/user-mapping.xml.erb
@@ -1,23 +1,33 @@
 <user-mapping>
 <% @usermap.each do |user, userdata| -%>
   <authorize username="<%= userdata['name'] -%>" password="<%= userdata['password'] -%>">
-  <% userdata['machines'].each do |type, settings| -%>
-    <connection name="<%= userdata['name'] + "-" + type -%>">
-    <% if settings['platform_family'] == 'windows' %>
-      <protocol>rdp</protocol>
-    <% else -%>
-      <protocol>ssh</protocol>
+  <% unless userdata['machines'].empty? -%>
+    <% userdata['machines'].each do |type, settings| -%>
+      <% unless settings.nil? -%>
+        <connection name="<%= userdata['name'] + "-" + type -%>">
+          <% if settings['platform_family'] == 'windows' %>
+        <protocol>rdp</protocol>
+          <% else -%>
+        <protocol>ssh</protocol>
+          <% end -%>
+        <param name="hostname"><%= settings['ec2']['local_hostname'] -%></param>
+          <% if settings['platform_family'] == 'windows' %>
+        <param name="port">3389</param>
+          <% else -%>
+        <param name="port">22</param>
+          <% end -%>
+        <param name="username"><%= settings['guacamole_user'] -%></param>
+          <% if settings['guacamole_key'] -%>
+        <param name="private-key">
+        <% IO.read(settings['guacamole_key']) %>
+        </param>
+          <%else -%>
+        <param name="password"><%= settings['guacamole_pass'] -%></param>
+          <% end -%>
+        <param name="ignore-cert">true</param>
+        </connection>
+      <% end -%>
     <% end -%>
-      <param name="hostname"><%= settings['ec2']['public_hostname'] -%></param>
-    <% if settings['platform_family'] == 'windows' %>
-      <param name="port">3389</param>
-    <% else -%>
-      <param name="port">22</param>
-    <% end -%>
-      <param name="username"><%= settings['guacamole_user'] -%></param>
-      <param name="password"><%= settings['guacamole_pass'] -%></param>
-      <param name="ignore-cert">true</param>
-    </connection>
   <% end -%>
   </authorize>
 <% end -%>

--- a/templates/default/user-mapping.xml.erb
+++ b/templates/default/user-mapping.xml.erb
@@ -18,9 +18,7 @@
           <% end -%>
         <param name="username"><%= settings['guacamole_user'] -%></param>
           <% if settings['guacamole_key'] -%>
-        <param name="private-key"><% File.open(settings['guacamole_key']).readlines.each do |line| -%>
-            <%= line %>
-          <% end %></param>
+        <param name="private-key"><% File.open(settings['guacamole_key']).readlines.each do |line| -%><%= line %><% end -%></param>
           <% else -%>
         <param name="password"><%= settings['guacamole_pass'] -%></param>
           <% end -%>

--- a/templates/default/user-mapping.xml.erb
+++ b/templates/default/user-mapping.xml.erb
@@ -11,24 +11,11 @@
       <param name="hostname"><%= settings['ec2']['public_hostname'] -%></param>
     <% if settings['platform_family'] == 'windows' %>
       <param name="port">3389</param>
-<<<<<<< HEAD
     <% else -%>
       <param name="port">22</param>
     <% end -%>
       <param name="username"><%= settings['guacamole_user'] -%></param>
       <param name="password"><%= settings['guacamole_pass'] -%></param>
-=======
-      <param name="username">chef</param>
-      <param name="password">CodeCan!</param>
-      <param name="ignore-cert">true</param>
-    </connection>
-    <connection name="student1-winnode">
-      <protocol>rdp</protocol>
-      <param name="hostname">52.27.107.153</param>
-      <param name="port">3389</param>
-      <param name="username">chef</param>
-      <param name="password">Cod3Can!</param>
->>>>>>> b5f0c89... Bump version and add some other stuff
       <param name="ignore-cert">true</param>
     </connection>
   <% end -%>

--- a/templates/default/user-mapping.xml.erb
+++ b/templates/default/user-mapping.xml.erb
@@ -19,7 +19,7 @@
         <param name="username"><%= settings['guacamole_user'] -%></param>
           <% if settings['guacamole_key'] -%>
         <param name="private-key"><% File.open(settings['guacamole_key']).readlines.each do |line| -%>
-            <% puts line %>
+            <%= line %>
           <% end %></param>
           <% else -%>
         <param name="password"><%= settings['guacamole_pass'] -%></param>

--- a/templates/default/user-mapping.xml.erb
+++ b/templates/default/user-mapping.xml.erb
@@ -11,11 +11,24 @@
       <param name="hostname"><%= settings['ec2']['public_hostname'] -%></param>
     <% if settings['platform_family'] == 'windows' %>
       <param name="port">3389</param>
+<<<<<<< HEAD
     <% else -%>
       <param name="port">22</param>
     <% end -%>
       <param name="username"><%= settings['guacamole_user'] -%></param>
       <param name="password"><%= settings['guacamole_pass'] -%></param>
+=======
+      <param name="username">chef</param>
+      <param name="password">CodeCan!</param>
+      <param name="ignore-cert">true</param>
+    </connection>
+    <connection name="student1-winnode">
+      <protocol>rdp</protocol>
+      <param name="hostname">52.27.107.153</param>
+      <param name="port">3389</param>
+      <param name="username">chef</param>
+      <param name="password">Cod3Can!</param>
+>>>>>>> b5f0c89... Bump version and add some other stuff
       <param name="ignore-cert">true</param>
     </connection>
   <% end -%>

--- a/templates/default/user-mapping.xml.erb
+++ b/templates/default/user-mapping.xml.erb
@@ -18,10 +18,10 @@
           <% end -%>
         <param name="username"><%= settings['guacamole_user'] -%></param>
           <% if settings['guacamole_key'] -%>
-        <param name="private-key">
-        <% IO.read(settings['guacamole_key']) %>
-        </param>
-          <%else -%>
+        <param name="private-key"><% File.open(settings['guacamole_key']).readlines.each do |line| -%>
+            <% puts line %>
+          <% end %></param>
+          <% else -%>
         <param name="password"><%= settings['guacamole_pass'] -%></param>
           <% end -%>
         <param name="ignore-cert">true</param>


### PR DESCRIPTION
This one probably needs some work, but you can see what I did here.

It's opinionated in that it forcefully uses node['ec2']['local_ipv4'] as the hostname endpoint.  It also introduces three new attributes that affect the rendering of user-mapping.xml. `guacamole_user` sets ssh or rdp username. `guacamole_key` is the filename to read in order to populate an ssh_key entry for ssh connections.  If `guacamole_key` is set, we will not write a password param line.  If `guacamole_key` is not set, then we read a password out of `guacamole_password`.

I know you want to make this publicly consumable.  So any pointers you have on how to sharpen this up for general consumption are welcome.  Happy to go build them as part of this PR.
